### PR TITLE
feat: add Bluesky SNS support

### DIFF
--- a/app/models/guest_interview_profile.rb
+++ b/app/models/guest_interview_profile.rb
@@ -26,4 +26,5 @@ class GuestInterviewProfile < ApplicationRecord
   has_many :answers, inverse_of: :guest_interview_profile
   has_many :questions_and_answers, primary_key: :id, inverse_of: :guest_interview_profile
   has_many :sns_x, inverse_of: :guest_interview_profile, class_name: 'GuestInterviewProfileSnsX'
+  has_many :sns_bluesky, inverse_of: :guest_interview_profile, class_name: 'GuestInterviewProfileSnsBluesky'
 end

--- a/app/models/guest_interview_profile_sns_bluesky.rb
+++ b/app/models/guest_interview_profile_sns_bluesky.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: guest_interview_profile_sns_blueskies
+#
+#  id                         :integer          not null, primary key
+#  account                    :string           not null
+#  guest_interview_profile_id :integer          not null
+#
+# Indexes
+#
+#  idx_on_guest_interview_profile_id_c93c656b70  (guest_interview_profile_id)
+#
+# Foreign Keys
+#
+#  guest_interview_profile_id  (guest_interview_profile_id => guest_interview_profiles.id)
+#
+class GuestInterviewProfileSnsBluesky < ApplicationRecord
+  belongs_to :guest_interview_profile
+  validates :account, format: { with: /\A[\w.-]+\z/ }
+
+  def mention
+    "@#{account}"
+  end
+end

--- a/app/views/episodes_sns/index.rss.builder
+++ b/app/views/episodes_sns/index.rss.builder
@@ -13,6 +13,11 @@ xml.rss version: '2.0', 'xmlns:atom': 'http://www.w3.org/2005/Atom' do
           episode_url(episode),
           hashtags(episode)
         ].join("\n")
+        xml.bluesky [
+          [episode.title, sns_mention(episode, :sns_bluesky)].join("\s"),
+          episode_url(episode),
+          hashtags(episode)
+        ].join("\n")
         xml.instagram_story_image episode_logo_image_url(episode)
 
         xml.pubDate episode.published_at.rfc822

--- a/bin/data/download_csvs_from_gsheet
+++ b/bin/data/download_csvs_from_gsheet
@@ -33,6 +33,7 @@ main() {
         guest_interview_profiles
         guest_interviews
         guest_interview_profile_sns_xes
+        guest_interview_profile_sns_blueskies
         questions
         hosts
         speakers

--- a/bin/data/import_from_csv
+++ b/bin/data/import_from_csv
@@ -28,6 +28,7 @@ main() {
         guests.csv
         guest_interview_profiles.csv
         guest_interview_profile_sns_xes.csv
+        guest_interview_profile_sns_blueskies.csv
         guest_interviews.csv
         questions.csv
         hosts.csv

--- a/db/migrate/20250801133953_create_guest_interview_profile_sns_blueskies.rb
+++ b/db/migrate/20250801133953_create_guest_interview_profile_sns_blueskies.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateGuestInterviewProfileSnsBlueskies < ActiveRecord::Migration[7.1]
+  def change
+    create_table :guest_interview_profile_sns_blueskies do |t|
+      t.references :guest_interview_profile, null: false, foreign_key: true
+      t.string :account, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_30_104305) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_01_133953) do
   create_table "answers", force: :cascade do |t|
     t.text "text", null: false
     t.date "answered_on", null: false
@@ -94,6 +94,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_30_104305) do
     t.index ["published_at"], name: "index_feeds_spotify_for_podcasters_on_published_at"
   end
 
+  create_table "guest_interview_profile_sns_blueskies", force: :cascade do |t|
+    t.integer "guest_interview_profile_id", null: false
+    t.string "account", null: false
+    t.index ["guest_interview_profile_id"], name: "idx_on_guest_interview_profile_id_c93c656b70"
+  end
+
   create_table "guest_interview_profile_sns_xes", force: :cascade do |t|
     t.integer "guest_interview_profile_id", null: false
     t.string "account", null: false
@@ -174,6 +180,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_30_104305) do
   add_foreign_key "episode_speakers", "speakers"
   add_foreign_key "episodes", "episode_types", column: "type_name", primary_key: "name"
   add_foreign_key "feeds_spotify_for_podcasters", "episodes", column: "episode_number", primary_key: "number"
+  add_foreign_key "guest_interview_profile_sns_blueskies", "guest_interview_profiles"
   add_foreign_key "guest_interview_profile_sns_xes", "guest_interview_profiles"
   add_foreign_key "guest_interview_profiles", "guests"
   add_foreign_key "guest_interviews", "episodes", column: "episode_number", primary_key: "number"
@@ -183,28 +190,28 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_30_104305) do
 
   create_view "published_episodes", sql_definition: <<-SQL
       SELECT
-                                                                           *
-                                                                          FROM episodes
-                                                                          JOIN feeds_spotify_for_podcasters ON feeds_spotify_for_podcasters.episode_number = episodes.number
+                                                                             *
+                                                                            FROM episodes
+                                                                            JOIN feeds_spotify_for_podcasters ON feeds_spotify_for_podcasters.episode_number = episodes.number
   SQL
   create_view "questions_and_answers", sql_definition: <<-SQL
       SELECT *, answers.text AS answer_text, topics.name AS topic_name, questions.text AS question_text
-                                                                          FROM answers
-                                                                          JOIN questions ON answers.question_number = questions.number
-                                                                          JOIN topics ON questions.topic_code = topics.code
-                                                                          ORDER BY topics.display_order ASC, questions.display_order ASC
+                                                                            FROM answers
+                                                                            JOIN questions ON answers.question_number = questions.number
+                                                                            JOIN topics ON questions.topic_code = topics.code
+                                                                            ORDER BY topics.display_order ASC, questions.display_order ASC
   SQL
   create_view "episode_transcriptions", sql_definition: <<-SQL
       SELECT *
-                                                                          FROM episode_speaker_transcriptions
-                                                                          INNER JOIN episode_speakers ON episode_speaker_transcriptions.episode_speaker_id = episode_speakers.id
-                                                                          INNER JOIN speakers ON episode_speakers.speaker_id = speakers.id
-                                                                          ORDER BY episode_number, start_at
+                                                                            FROM episode_speaker_transcriptions
+                                                                            INNER JOIN episode_speakers ON episode_speaker_transcriptions.episode_speaker_id = episode_speakers.id
+                                                                            INNER JOIN speakers ON episode_speakers.speaker_id = speakers.id
+                                                                            ORDER BY episode_number, start_at
   SQL
   create_view "unpublished_episodes", sql_definition: <<-SQL
       SELECT *
-                                                                          FROM episodes
-                                                                          LEFT OUTER JOIN feeds_spotify_for_podcasters ON feeds_spotify_for_podcasters.episode_number = episodes.number
-                                                                          WHERE feeds_spotify_for_podcasters.episode_number IS NULL
+                                                                            FROM episodes
+                                                                            LEFT OUTER JOIN feeds_spotify_for_podcasters ON feeds_spotify_for_podcasters.episode_number = episodes.number
+                                                                            WHERE feeds_spotify_for_podcasters.episode_number IS NULL
   SQL
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -59,6 +59,11 @@ FOREIGN KEY ("episode_number")
 );
 CREATE UNIQUE INDEX "index_feeds_spotify_for_podcasters_on_episode_number" ON "feeds_spotify_for_podcasters" ("episode_number");
 CREATE INDEX "index_feeds_spotify_for_podcasters_on_published_at" ON "feeds_spotify_for_podcasters" ("published_at");
+CREATE TABLE IF NOT EXISTS "guest_interview_profile_sns_xes" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "guest_interview_profile_id" integer NOT NULL, "account" varchar NOT NULL, CONSTRAINT "fk_rails_8a7c60103e"
+FOREIGN KEY ("guest_interview_profile_id")
+  REFERENCES "guest_interview_profiles" ("id")
+);
+CREATE INDEX "idx_on_guest_interview_profile_id_b309d95290" ON "guest_interview_profile_sns_xes" ("guest_interview_profile_id");
 CREATE TABLE IF NOT EXISTS "guest_interview_profiles" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "guest_id" integer NOT NULL, "job_title" varchar NOT NULL, "introduction" text NOT NULL, "abroad_living_summary" varchar NOT NULL, "guest_name" varchar NOT NULL, "image_path" varchar NOT NULL, "interviewed_on" date NOT NULL, CONSTRAINT "fk_rails_f9437323b7"
 FOREIGN KEY ("guest_id")
   REFERENCES "guests" ("id")
@@ -84,35 +89,36 @@ FOREIGN KEY ("topic_code")
 , CONSTRAINT chk_rails_3b193a7e50 CHECK (display_order > 0));
 CREATE UNIQUE INDEX "index_questions_on_topic_code_and_display_order" ON "questions" ("topic_code", "display_order");
 CREATE VIEW "published_episodes" AS       SELECT
-                                                                         *
-                                                                        FROM episodes
-                                                                        JOIN feeds_spotify_for_podcasters ON feeds_spotify_for_podcasters.episode_number = episodes.number
+                                                                           *
+                                                                          FROM episodes
+                                                                          JOIN feeds_spotify_for_podcasters ON feeds_spotify_for_podcasters.episode_number = episodes.number
 /* published_episodes(number,title,summary,long_summary,subtitle,season_number,story_number,type_name,image_path,episode_number,source_url,"title:1",url,audio_file_url,image_url,published_at,description,duration,explicit,"season_number:1","story_number:1",episode_type,guid,creator) */;
 CREATE VIEW "questions_and_answers" AS       SELECT *, answers.text AS answer_text, topics.name AS topic_name, questions.text AS question_text
-                                                                        FROM answers
-                                                                        JOIN questions ON answers.question_number = questions.number
-                                                                        JOIN topics ON questions.topic_code = topics.code
-                                                                        ORDER BY topics.display_order ASC, questions.display_order ASC
+                                                                          FROM answers
+                                                                          JOIN questions ON answers.question_number = questions.number
+                                                                          JOIN topics ON questions.topic_code = topics.code
+                                                                          ORDER BY topics.display_order ASC, questions.display_order ASC
 /* questions_and_answers(id,text,answered_on,question_number,original_question_text,guest_interview_profile_id,number,"text:1",display_order,topic_code,about,code,name,"display_order:1",answer_text,topic_name,question_text) */;
 CREATE VIEW "episode_transcriptions" AS       SELECT *
-                                                                        FROM episode_speaker_transcriptions
-                                                                        INNER JOIN episode_speakers ON episode_speaker_transcriptions.episode_speaker_id = episode_speakers.id
-                                                                        INNER JOIN speakers ON episode_speakers.speaker_id = speakers.id
-                                                                        ORDER BY episode_number, start_at
+                                                                          FROM episode_speaker_transcriptions
+                                                                          INNER JOIN episode_speakers ON episode_speaker_transcriptions.episode_speaker_id = episode_speakers.id
+                                                                          INNER JOIN speakers ON episode_speakers.speaker_id = speakers.id
+                                                                          ORDER BY episode_number, start_at
 /* episode_transcriptions(id,episode_speaker_id,text,start_at,end_at,"id:1",episode_number,speaker_id,role_name,"id:2",name,image_path,global_id) */;
 CREATE VIEW "unpublished_episodes" AS       SELECT *
-                                                                        FROM episodes
-                                                                        LEFT OUTER JOIN feeds_spotify_for_podcasters ON feeds_spotify_for_podcasters.episode_number = episodes.number
-                                                                        WHERE feeds_spotify_for_podcasters.episode_number IS NULL
+                                                                          FROM episodes
+                                                                          LEFT OUTER JOIN feeds_spotify_for_podcasters ON feeds_spotify_for_podcasters.episode_number = episodes.number
+                                                                          WHERE feeds_spotify_for_podcasters.episode_number IS NULL
 /* unpublished_episodes(number,title,summary,long_summary,subtitle,season_number,story_number,type_name,image_path,episode_number,source_url,"title:1",url,audio_file_url,image_url,published_at,description,duration,explicit,"season_number:1","story_number:1",episode_type,guid,creator) */;
 CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
 CREATE TABLE IF NOT EXISTS "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
-CREATE TABLE IF NOT EXISTS "guest_interview_profile_sns_xes" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "guest_interview_profile_id" integer NOT NULL, "account" varchar NOT NULL, CONSTRAINT "fk_rails_8a7c60103e"
+CREATE TABLE IF NOT EXISTS "guest_interview_profile_sns_blueskies" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "guest_interview_profile_id" integer NOT NULL, "account" varchar NOT NULL, CONSTRAINT "fk_rails_8dfd5d042c"
 FOREIGN KEY ("guest_interview_profile_id")
   REFERENCES "guest_interview_profiles" ("id")
 );
-CREATE INDEX "idx_on_guest_interview_profile_id_b309d95290" ON "guest_interview_profile_sns_xes" ("guest_interview_profile_id");
+CREATE INDEX "idx_on_guest_interview_profile_id_c93c656b70" ON "guest_interview_profile_sns_blueskies" ("guest_interview_profile_id");
 INSERT INTO "schema_migrations" (version) VALUES
+('20250801133953'),
 ('20250730104305'),
 ('20250110083100'),
 ('20250110074723'),

--- a/test/fixtures/guest_interview_profile_sns_blueskies.yml
+++ b/test/fixtures/guest_interview_profile_sns_blueskies.yml
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: guest_interview_profile_sns_blueskies
+#
+#  id                         :integer          not null, primary key
+#  account                    :string           not null
+#  guest_interview_profile_id :integer          not null
+#
+# Indexes
+#
+#  idx_on_guest_interview_profile_id_c93c656b70  (guest_interview_profile_id)
+#
+# Foreign Keys
+#
+#  guest_interview_profile_id  (guest_interview_profile_id => guest_interview_profiles.id)
+#
+
+one:
+  guest_interview_profile: one
+  account: bluesky_account_one
+
+one_two:
+  guest_interview_profile: one
+  account: bluesky_account_one_two
+
+two:
+  guest_interview_profile: two
+  account: bluesky_account_two

--- a/test/models/guest_interview_profile_sns_bluesky_test.rb
+++ b/test/models/guest_interview_profile_sns_bluesky_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: guest_interview_profile_sns_blueskies
+#
+#  id                         :integer          not null, primary key
+#  account                    :string           not null
+#  guest_interview_profile_id :integer          not null
+#
+# Indexes
+#
+#  idx_on_guest_interview_profile_id_c93c656b70  (guest_interview_profile_id)
+#
+# Foreign Keys
+#
+#  guest_interview_profile_id  (guest_interview_profile_id => guest_interview_profiles.id)
+#
+require 'test_helper'
+
+class GuestInterviewProfileSnsBlueskyTest < ActiveSupport::TestCase
+  test 'should have correct attributes and relations' do
+    assert_equal guest_interview_profiles(:one), guest_interview_profile_sns_blueskies(:one).guest_interview_profile
+  end
+
+  test 'mention returns with @' do
+    assert_equal '@bluesky_account_one', guest_interview_profile_sns_blueskies(:one).mention
+  end
+
+  test '#account should allow particular letters including dots' do
+    sns_bluesky = guest_interview_profile_sns_blueskies(:one)
+
+    sns_bluesky.account = "@#{sns_bluesky.account} "
+    assert_equal false, sns_bluesky.valid?
+    sns_bluesky.account = ' one'
+    assert_equal false, sns_bluesky.valid?
+    sns_bluesky.account = 'one '
+    assert_equal false, sns_bluesky.valid?
+    sns_bluesky.account = 'on e'
+    assert_equal false, sns_bluesky.valid?
+
+    sns_bluesky.account = 'one.1-'
+    assert sns_bluesky.valid?
+    sns_bluesky.account = 'user.bsky.social'
+    assert sns_bluesky.valid?
+  end
+end

--- a/test/models/guest_interview_profiles_test.rb
+++ b/test/models/guest_interview_profiles_test.rb
@@ -37,5 +37,7 @@ class GuestInterviewProfilesTest < ActiveSupport::TestCase
 
     assert_equal [guest_interview_profile_sns_xes(:one), guest_interview_profile_sns_xes(:one_two)],
                  guest_interview_profiles(:one).sns_x
+    assert_equal [guest_interview_profile_sns_blueskies(:one), guest_interview_profile_sns_blueskies(:one_two)],
+                 guest_interview_profiles(:one).sns_bluesky
   end
 end


### PR DESCRIPTION
## Summary
- Add support for Bluesky social media accounts for guest interview profiles
- Follows the same pattern as the existing X (Twitter) implementation
- Adds `<bluesky>` XML elements to the episodes_sns RSS feed

## Changes
- **Model**: New `GuestInterviewProfileSnsBluesky` with account validation
- **Association**: Added `sns_bluesky` relationship to `GuestInterviewProfile`
- **RSS Feed**: Updated episodes_sns RSS to include Bluesky mentions
- **Data Import**: Updated CSV scripts to support Bluesky data
- **Tests**: Comprehensive test coverage for all new functionality

## Test Plan
- [x] All existing tests pass (112 runs, 271 assertions, 0 failures)
- [x] New Bluesky model tests validate account format
- [x] RSS feed generates both X and Bluesky XML elements correctly
- [x] Data import scripts updated to handle new CSV format

🤖 Generated with [Claude Code](https://claude.ai/code)