### PR TITLE
feat: add English locale support with environment variable override

### DIFF
--- a/bin/data/import_from_csv
+++ b/bin/data/import_from_csv
@@ -18,6 +18,8 @@ fi
 cd "$(dirname "$0")"
 cd ../..
 
+export LOCALE=en # to avoid the error of "I18n.locale is not set"
+
 main() {
     csv_dir=$1
     base_csv_file_names=(

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -4,3 +4,4 @@ I18n.load_path += Dir[Rails.root.join('config/locales/**/*.yml')]
 I18n.available_locales = %i[en ja]
 I18n.default_locale = :ja
 I18n.fallbacks = %i[ja]
+I18n.locale = ENV['LOCALE'].to_sym if ENV.key?('LOCALE')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,8 @@ en:
   hello: "Hello world"
   error:
     forbidden: "forbidden"
+  site:
+    name: Living Overseas
+    description: |
+      Interviewing people who lives overseas, mainly Japanese. https://en.kaigaiiju.ch/
+      This is the (AI) translated version of the original japanese podcast: Kaigai-ijuh channel https://kaigaiiju.ch/


### PR DESCRIPTION
## Summary
- Add LOCALE environment variable support in i18n initializer to enable dynamic locale switching
- Add English translations for site name and description in config/locales/en.yml
- Set LOCALE=en in bin/data/import_from_csv script to prevent i18n errors during data import

## Changes Made
- **config/initializers/i18n.rb**: Added `I18n.locale = ENV['LOCALE'].to_sym if ENV.key?('LOCALE')` to support environment-based locale override
- **config/locales/en.yml**: Added English translations for site name and description
- **bin/data/import_from_csv**: Set `export LOCALE=en` to avoid i18n locale errors during CSV import

## Test plan
- [ ] Verify English locale works when LOCALE=en environment variable is set
- [ ] Test that CSV import script runs without i18n errors
- [ ] Confirm Japanese remains the default locale when LOCALE is not set
- [ ] Check that site name and description display correctly in English context

🤖 Generated with [Claude Code](https://claude.ai/code)