### PR TITLE
feat: Instagram story image RSS improvements

### DIFF
--- a/app/helpers/episodes_helper.rb
+++ b/app/helpers/episodes_helper.rb
@@ -27,7 +27,7 @@ module EpisodesHelper
         .gsub(MARKDOWN_LINK_REGEX, link_to('\1', '\2', target: '_blank', rel: 'noopener'))
   end
 
-  def episode_logo_image_url(episode) # rubocop:disable Metrics/MethodLength
+  def episode_instagram_story_image_url(episode) # rubocop:disable Metrics/MethodLength
     cl_image_path(
       ENV.fetch('CLOUDINARY_STORY_IMAGE'),
       transformation: [

--- a/app/views/episodes/index.rss.builder
+++ b/app/views/episodes/index.rss.builder
@@ -15,7 +15,6 @@ xml.rss version: '2.0', 'xmlns:atom': 'http://www.w3.org/2005/Atom' do
           xml.description(render(partial: 'descriptions/episodes/description', locals: { episode: }, formats: :html))
         end
         xml.image image_url_with_host(episode.image_path)
-        xml.logo_image episode_logo_image_url(episode)
 
         xml.pubDate episode.published_at.rfc822
         xml.link episode_url(episode)

--- a/app/views/episodes_sns/index.rss.builder
+++ b/app/views/episodes_sns/index.rss.builder
@@ -18,7 +18,7 @@ xml.rss version: '2.0', 'xmlns:atom': 'http://www.w3.org/2005/Atom' do
           episode_url(episode),
           hashtags(episode)
         ].join("\n")
-        xml.instagram_story_image episode_logo_image_url(episode)
+        xml.instagram_story_image episode_instagram_story_image_url(episode)
 
         xml.pubDate episode.published_at.rfc822
         xml.link episode_url(episode)


### PR DESCRIPTION
## Summary
- Rename `episode_logo_image_url` method to `episode_instagram_story_image_url` for better clarity
- Remove unused `logo_image` XML element from main RSS feed
- Update SNS RSS feed to use the renamed method for Instagram story images

## Changes
- **Method rename**: `episode_logo_image_url` → `episode_instagram_story_image_url` in `app/helpers/episodes_helper.rb:30`
- **RSS cleanup**: Remove `xml.logo_image` line from main episodes RSS feed (`app/views/episodes/index.rss.builder:18`)
- **RSS update**: Use renamed method in SNS RSS feed (`app/views/episodes_sns/index.rss.builder:21`)

## Test plan
- [ ] Verify main RSS feed builds without logo_image element
- [ ] Confirm SNS RSS feed includes instagram_story_image with correct URL
- [ ] Check that Instagram story image URLs are generated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)